### PR TITLE
set up continuous integration

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,18 +37,3 @@ jobs:
       - name: Install dos2unix on Linux
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y dos2unix
-
-      - name: Install dos2unix on macOS
-        if: runner.os == 'macOS'
-        run: brew install dos2unix
-
-      - name: Perform IO redirection test (*NIX or macOS)
-        if: runner.os == 'Linux' || runner.os == 'macOS'
-        working-directory: ${{ github.workspace }}/text-ui-test
-        run: ./runtest.sh
-
-      - name: Perform IO redirection test (Windows)
-        if: always() && runner.os == 'Windows'
-        working-directory: ${{ github.workspace }}/text-ui-test
-        shell: cmd
-        run: runtest.bat


### PR DESCRIPTION
Add .github/workflows/gradle.yml in root so that on every push and pull request the test cases can be automatically run.

If tests failed, users are alerted to the fact that there are some issues with the code that is pushed. Allowing developers to do a hot fix.